### PR TITLE
Created admin-panel guard with canActivate and canLoad

### DIFF
--- a/src/app/admin-panel/admin-panel.guard.spec.ts
+++ b/src/app/admin-panel/admin-panel.guard.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { AdminPanelGuard } from './admin-panel.guard';
+
+describe('AdminPanelGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AdminPanelGuard]
+    });
+  });
+
+  it('should ...', inject([AdminPanelGuard], (guard: AdminPanelGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/src/app/admin-panel/admin-panel.guard.ts
+++ b/src/app/admin-panel/admin-panel.guard.ts
@@ -1,0 +1,54 @@
+import {Injectable} from '@angular/core';
+import {CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, CanLoad} from '@angular/router';
+import {TokenInfo} from '../models/token-info';
+import * as JWTDecoder from 'jwt-decode';
+import {AuthService} from '../services/auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AdminPanelGuard implements CanLoad, CanActivate {
+  constructor(private authService: AuthService) {
+  }
+
+  /**
+   * Function that allow user to navigate to other route modules if it returns true
+   * checks permission every time
+   * @returns true if user's role is not ROLE_ADMIN
+   * @returns false if user's role is ROLE_ADMIN
+   */
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): boolean  {
+    if (this.checkRole()) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Function that allows user to navigate to other route modules if it returns true
+   * checks permissions only first time
+   * @returns true if user's role is not ROLE_ADMIN
+   * @returns false if user's role is ROLE_ADMIN
+   */
+  canLoad(): boolean {
+    if (this.checkRole()) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Function that checks user's role -
+   * @returns true if user's role == ROLE_ADMIN
+   */
+  private checkRole(): boolean {
+    const decodedToken: TokenInfo = JWTDecoder(this.authService.getToken());
+    const role: string = decodedToken.Roles.authority;
+    if (role === 'ROLE_ADMIN') {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/app/shell/shell-routing.module.ts
+++ b/src/app/shell/shell-routing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import {ShellComponent} from './shell/shell.component';
-
+import {AdminPanelGuard} from '../admin-panel/admin-panel.guard';
 
 const routes: Routes = [
   {
@@ -10,14 +10,20 @@ const routes: Routes = [
   },
   {
     path: 'journal',
+    canActivate: [AdminPanelGuard],
+    canLoad: [AdminPanelGuard],
     loadChildren: '../journal/journal.module#JournalModule'
   },
   {
     path: 'progress',
+    canActivate: [AdminPanelGuard],
+    canLoad: [AdminPanelGuard],
     loadChildren: '../progress/progress.module#ProgressModule'
   },
   {
     path: 'student-book',
+    canActivate: [AdminPanelGuard],
+    canLoad: [AdminPanelGuard],
     loadChildren: '../student-book/student-book.module#StudentBookModule'
   },
   {


### PR DESCRIPTION
Created admin-panel guard with canActivate and canLoad guards, which does not give permission for admin to navigate to journal, student-book and progress router modules.